### PR TITLE
Create CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,55 @@
+Squot, Squit, VersionControl, additions and changes to FileSystem-Git, FileSystem
+=================================================================================
+Jakob Reschke,
+Fabio Niephaus,
+Tom Beckmann,
+Corinna Jaschek,
+Marcel Taeumel,
+Patrick Rein
+
+Note: some methods in FileSystem have been picked from Pharo, since it uses FileSystem as the default file access library.
+
+Previous incarnations
+=====================
+
+FileSystem-Git
+--------------
+###### (formerly FSGit, GitFS, MonticelloGit, Git for Squeak)
+
+Previous repositories:
+- http://smalltalkhub.com/#!/~FileSystemGitDev/FileSystem-Git/
+- http://ss3.gemstone.com/ss/FileSystem-Git.html
+- https://github.com/dalehenrich/FSGit
+- http://www.squeaksource.com/FSGit.html
+- http://www.squeaksource.com/GitFS.html
+- http://www.squeaksource.com/Git.html
+
+Camillo Bruni,
+Damien Cassou,
+Tony Garnock-Jones,
+Max Leske,
+Stefan Marr,
+Lukas Renggli,
+[Peter](http://smalltalkhub.com/#!/~dh83)
+
+
+FileSystem
+----------
+Previous repository:
+- http://www.squeaksource.com/fs.html
+
+Colin Putney,
+Camillo Bruni,
+Damien Cassou,
+Marcus Denker,
+Stéphane Ducasse,
+Tudor Girba,
+Jannik Laval,
+Max Leske,
+hfm,
+tbn,
+Sean de Nigris,
+Nicolas Passerini,
+Damien Pollet,
+Lukas Renggli,
+Igor Stasenko


### PR DESCRIPTION
Offers a proper view on the history of FileSystem-Git and FileSystem
and communicates that they have been conceived by other people.
Took a while to collect the names from the various sources of history.

I am not sure whether I would first have to ask all the people whether they (still) want their names on these things. In particular in the context of this repository. Opinions?