### PR TITLE
Create a rolling MCVersionInfo for all projects.

### DIFF
--- a/src/Squot.package/MCFileTreeWriterWithSettableFileUtils.class/instance/addString.at.encodedTo..st
+++ b/src/Squot.package/MCFileTreeWriterWithSettableFileUtils.class/instance/addString.at.encodedTo..st
@@ -1,0 +1,17 @@
+accessing
+addString: string at: fileNameOrPath encodedTo: ignored
+    "fileNameOrPath may have one or two elements"
+    "encodeTo: arg, because FileTree uses UTF8 by default"
+
+    | fullPath path |
+    path := MCFileTreePackageStructureStWriter useCypressWriter
+        ifTrue: [ 
+            fullPath := self fileUtils
+                buildPathFrom:
+                    {(MCFileTreeStCypressWriter monticelloMetaDirName).
+                    fileNameOrPath}.
+            self fileUtils ensureFilePathExists: fullPath relativeTo: self packageFileDirectory.
+            fullPath ]
+        ifFalse: [ fileNameOrPath ].
+    string isEmpty
+        ifFalse: [ self fileUtils writeStreamFor: path in: self packageFileDirectory do: [ :file | file nextPutAll: string ] ]

--- a/src/Squot.package/MCFileTreeWriterWithSettableFileUtils.class/methodProperties.json
+++ b/src/Squot.package/MCFileTreeWriterWithSettableFileUtils.class/methodProperties.json
@@ -2,6 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
+		"addString:at:encodedTo:" : "LM 3/19/2019 22:45",
 		"directory:" : "jr 1/20/2017 15:41",
 		"fileUtils" : "jr 1/17/2017 13:43",
 		"fileUtils:" : "jr 1/17/2017 13:46" } }

--- a/src/Squot.package/SquotCypressCodeSerializer.class/instance/packageNameFromPackageDirectory.st
+++ b/src/Squot.package/SquotCypressCodeSerializer.class/instance/packageNameFromPackageDirectory.st
@@ -1,0 +1,5 @@
+private
+packageNameFromPackageDirectory
+    | filename |
+    filename := fileUtils directoryName: self directory.
+    ^ filename copyFrom: 1 to: (filename lastIndexOf: $.) - 1

--- a/src/Squot.package/SquotCypressCodeSerializer.class/instance/rollingVersionInfo.st
+++ b/src/Squot.package/SquotCypressCodeSerializer.class/instance/rollingVersionInfo.st
@@ -1,0 +1,15 @@
+private
+rollingVersionInfo
+
+	"This allows users to easily update Squot projects that are installed using Metacello.
+If the version of the project the user requests to install is not higher than the currently installed version, Metacello will not install the newly requested version.
+	As git projects usually don't have incrementing version numbers, using the seconds since unix time is a good enough workaround, as it simply generates an ever-increasing version number."
+	^MCVersionInfo
+	    name: self packageNameFromPackageDirectory , '-squot.', DateAndTime totalSeconds asString
+	    id: UUID new
+	    message: 'created from a Squot Artifact.'
+	    date: Date today
+	    time: Time now
+	    author: Utilities authorInitials
+	    ancestors: #()
+	    stepChildren: #()

--- a/src/Squot.package/SquotCypressCodeSerializer.class/instance/writePackage..st
+++ b/src/Squot.package/SquotCypressCodeSerializer.class/instance/writePackage..st
@@ -1,4 +1,6 @@
 private
 writePackage: anArtifact
 	self initializeFileTreeWritersInPackageDirectory: (rootDirectory resolve: anArtifact path).
+	fileTreeWriter writeVersionInfo: self rollingVersionInfo.
+	fileTreeWriter writePackage: (MCPackage named: self packageNameFromPackageDirectory).
 	anArtifact shadowOfTrackedObject squotWrite: anArtifact with: self.

--- a/src/Squot.package/SquotCypressCodeSerializer.class/methodProperties.json
+++ b/src/Squot.package/SquotCypressCodeSerializer.class/methodProperties.json
@@ -11,10 +11,12 @@
 		"directory" : "jr 1/17/2017 14:24",
 		"initialize" : "jr 2/26/2017 13:55",
 		"initializeFileTreeWritersInPackageDirectory:" : "jr 2/26/2017 13:56",
+		"packageNameFromPackageDirectory" : "LM 3/19/2019 22:57",
 		"propertyFileExtension" : "jr 1/17/2017 15:19",
+		"rollingVersionInfo" : "LM 5/4/2020 19:56",
 		"version" : "jr 1/15/2017 19:07",
 		"write:" : "jr 5/9/2017 18:24",
 		"writeClass:" : "jr 7/27/2017 23:53",
 		"writeDefinitions:" : "jr 1/29/2017 21:08",
 		"writeMCSnapshot:forPackageNamed:from:" : "jr 3/16/2019 23:35",
-		"writePackage:" : "jr 7/22/2017 02:03" } }
+		"writePackage:" : "LM 3/19/2019 23:27" } }

--- a/src/Squot.package/monticello.meta/package
+++ b/src/Squot.package/monticello.meta/package
@@ -1,0 +1,1 @@
+(name 'Squot')

--- a/src/Squot.package/monticello.meta/version
+++ b/src/Squot.package/monticello.meta/version
@@ -1,0 +1,1 @@
+(name 'Squot-squot.3766074984' message 'created from a Squot Artifact.' id '816b54db-b88b-4f30-99f1-2fc71707d612' date '4 May 2020' time '7:56:24.933709 pm' author 'LM' ancestors () stepChildren ())


### PR DESCRIPTION
This allows users to easily update Squot projects that are installed using Metacello.
If the version of the project the user requests to install is not higher than the currently installed version, Metacello will not install the newly requested version.

This patch essentially fakes a version number by simply using the seconds since start of the Unix epoch. Whilst not ideal, it is a good-enough workaround for, as git commits don't have a single incrementing version number.

I've used this patch for a while now with great success in my [Autocompletion](https://github.com/MrModder/Autocompletion) project.
The artifacts generated by this patch look like this:
https://github.com/MrModder/Autocompletion/blob/master/packages/Autocompletion.package/monticello.meta/package
https://github.com/MrModder/Autocompletion/blob/master/packages/Autocompletion.package/monticello.meta/version