### PR TITLE
Fixes #270, promise rejection not passed on

### DIFF
--- a/.squot
+++ b/.squot
@@ -1,10 +1,10 @@
 OrderedDictionary {
-	'src\/VersionControl.package' : #SquotCypressCodeSerializer,
-	'src\/Pharo-compatibility.package' : #SquotCypressCodeSerializer,
-	'src\/Squot.package' : #SquotCypressCodeSerializer,
-	'src\/FileSystem-Git.package' : #SquotCypressCodeSerializer,
-	'src\/Squit.package' : #SquotCypressCodeSerializer,
-	'src\/BaselineOfSquot.package' : #SquotCypressCodeSerializer,
-	'src\/SquotTonel-Core.package' : #SquotCypressCodeSerializer,
-	'src\/SquotTonel-Tests.package' : #SquotCypressCodeSerializer
+	'src/VersionControl.package' : #SquotCypressCodeSerializer,
+	'src/Pharo-compatibility.package' : #SquotCypressCodeSerializer,
+	'src/Squot.package' : #SquotCypressCodeSerializer,
+	'src/FileSystem-Git.package' : #SquotCypressCodeSerializer,
+	'src/Squit.package' : #SquotCypressCodeSerializer,
+	'src/BaselineOfSquot.package' : #SquotCypressCodeSerializer,
+	'src/SquotTonel-Core.package' : #SquotCypressCodeSerializer,
+	'src/SquotTonel-Tests.package' : #SquotCypressCodeSerializer
 }

--- a/.squot
+++ b/.squot
@@ -1,10 +1,10 @@
 OrderedDictionary {
-	'src/VersionControl.package' : #SquotCypressCodeSerializer,
-	'src/Pharo-compatibility.package' : #SquotCypressCodeSerializer,
-	'src/Squot.package' : #SquotCypressCodeSerializer,
-	'src/FileSystem-Git.package' : #SquotCypressCodeSerializer,
-	'src/Squit.package' : #SquotCypressCodeSerializer,
-	'src/BaselineOfSquot.package' : #SquotCypressCodeSerializer,
-	'src/SquotTonel-Core.package' : #SquotCypressCodeSerializer,
-	'src/SquotTonel-Tests.package' : #SquotCypressCodeSerializer
+	'src\/VersionControl.package' : #SquotCypressCodeSerializer,
+	'src\/Pharo-compatibility.package' : #SquotCypressCodeSerializer,
+	'src\/Squot.package' : #SquotCypressCodeSerializer,
+	'src\/FileSystem-Git.package' : #SquotCypressCodeSerializer,
+	'src\/Squit.package' : #SquotCypressCodeSerializer,
+	'src\/BaselineOfSquot.package' : #SquotCypressCodeSerializer,
+	'src\/SquotTonel-Core.package' : #SquotCypressCodeSerializer,
+	'src\/SquotTonel-Tests.package' : #SquotCypressCodeSerializer
 }

--- a/src/Squot.package/SquotInteractiveCherryPick.class/instance/save.st
+++ b/src/Squot.package/SquotInteractiveCherryPick.class/instance/save.st
@@ -9,4 +9,4 @@ save
 				[:reason |
 				self requestor getShouldRevertCherryPickedChanges ifTrue:
 					[self revertMerge "captured snapshot used here"].
-				'Save was cancelled']
+				Promise new rejectWith: 'Save was cancelled']

--- a/src/Squot.package/SquotInteractiveCherryPick.class/methodProperties.json
+++ b/src/Squot.package/SquotInteractiveCherryPick.class/methodProperties.json
@@ -6,5 +6,5 @@
 		"applyToWorkingCopy" : "jr 4/17/2020 19:56",
 		"privateNewMerge" : "jr 1/19/2020 01:43",
 		"privateNewSave" : "jr 1/26/2020 21:56",
-		"save" : "jr 2/1/2020 00:15",
+		"save" : "tobe 6/14/2020 06:59",
 		"validateRequestor" : "jr 1/7/2020 00:04" } }

--- a/src/Squot.package/SquotInteractiveMerge.class/instance/chooseChanges.st
+++ b/src/Squot.package/SquotInteractiveMerge.class/instance/chooseChanges.st
@@ -7,4 +7,4 @@ chooseChanges
 		controllerForIgnores: self.
 	^ (tool selectedChangesWithTitle: self title)
 		then: [:ignored | merge resolvedPatch]
-		ifRejected: [:ignored | 'Merge was cancelled']
+		ifRejected: [:ignored | Promise new rejectWith: 'Merge was cancelled']

--- a/src/Squot.package/SquotInteractiveMerge.class/methodProperties.json
+++ b/src/Squot.package/SquotInteractiveMerge.class/methodProperties.json
@@ -3,4 +3,4 @@
 		 },
 	"instance" : {
 		"applyToWorkingCopy" : "jr 4/17/2020 12:44",
-		"chooseChanges" : "jr 1/28/2020 23:03" } }
+		"chooseChanges" : "tobe 6/14/2020 06:57" } }

--- a/src/Squot.package/SquotInteractiveSave.class/instance/chooseChanges.st
+++ b/src/Squot.package/SquotInteractiveSave.class/instance/chooseChanges.st
@@ -17,4 +17,4 @@ chooseChanges
 		ifRejected: [:ignored |
 			tool messageWasChanged
 				ifTrue: [self workingCopy newVersionMessage: tool message asString].
-			'Save was canceled']
+			Promise new rejectWith: 'Save was canceled']

--- a/src/Squot.package/SquotInteractiveSave.class/methodProperties.json
+++ b/src/Squot.package/SquotInteractiveSave.class/methodProperties.json
@@ -2,6 +2,6 @@
 	"class" : {
 		 },
 	"instance" : {
-		"applyToWorkingCopy" : "jr 4/17/2020 18:05",
-		"chooseChanges" : "jr 1/28/2020 23:49",
+		"applyToWorkingCopy" : "tobe 6/14/2020 06:58",
+		"chooseChanges" : "tobe 6/14/2020 06:57",
 		"validate" : "jr 5/22/2020 16:00" } }


### PR DESCRIPTION
Promises in the save dialog did not pass on the fact that they were rejected, instead catching the rejection and then resolving (think of it like a try-catch that doesn't re-throw)