### PR TITLE
tonel package locator: fix heuristic to not yield false positives inside cypress dirs

### DIFF
--- a/src/SquotTonel-Core.package/SquotFileSystemStore.extension/instance/isInsideCypressDirectory..st
+++ b/src/SquotTonel-Core.package/SquotFileSystemStore.extension/instance/isInsideCypressDirectory..st
@@ -2,5 +2,4 @@
 isInsideCypressDirectory: aFile
 	" guess if we are inside a Cypress directory right now which happens to contain a package.st file "
 
-	^ (aFile parent ifNotNil: [:p | p parent ifNotNil: [:package | package name endsWith: '.package']])
-		ifNil: [true]
+	^ (aFile resolve: '../..') name endsWith: '.package'

--- a/src/SquotTonel-Core.package/SquotFileSystemStore.extension/instance/isInsideCypressDirectory..st
+++ b/src/SquotTonel-Core.package/SquotFileSystemStore.extension/instance/isInsideCypressDirectory..st
@@ -1,0 +1,6 @@
+*SquotTonel-Core-guessing
+isInsideCypressDirectory: aFile
+	" guess if we are inside a Cypress directory right now which happens to contain a package.st file "
+
+	^ (aFile parent ifNotNil: [:p | p parent ifNotNil: [:package | package name endsWith: '.package']])
+		ifNil: [true]

--- a/src/SquotTonel-Core.package/SquotFileSystemStore.extension/instance/tonelPackageLocator.st
+++ b/src/SquotTonel-Core.package/SquotFileSystemStore.extension/instance/tonelPackageLocator.st
@@ -8,7 +8,7 @@ tonelPackageLocator
 				ifTrue: [(fileOrDirectory entries
 							anySatisfy: 	[:eachEntry |
 											eachEntry basename = 'package.st' and:
-											[eachEntry isFile]])
+											[eachEntry isFile and: [(self isInsideCypressDirectory: fileOrDirectory) not]]])
 							ifTrue: [search addArtifact:
 										(self forgeLazyArtifactAt: fileOrDirectory
 											deserializerFactory: SquotTonelDeserializer

--- a/src/SquotTonel-Core.package/SquotFileSystemStore.extension/methodProperties.json
+++ b/src/SquotTonel-Core.package/SquotFileSystemStore.extension/methodProperties.json
@@ -2,4 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"tonelPackageLocator" : "jr 3/10/2019 21:26" } }
+		"isInsideCypressDirectory:" : "tobe 1/6/2021 12:58",
+		"tonelPackageLocator" : "tobe 1/6/2021 12:58" } }

--- a/src/SquotTonel-Tests.package/SquotTonelPackageLocatorTest.class/instance/testIgnoresCypressPackagesWithMethodNamedPackage.st
+++ b/src/SquotTonel-Tests.package/SquotTonelPackageLocatorTest.class/instance/testIgnoresCypressPackagesWithMethodNamedPackage.st
@@ -1,0 +1,10 @@
+tests
+testIgnoresCypressPackagesWithMethodNamedPackage
+	| artifactsFound |
+	(rootDirectory / 'Xyz.package' / 'A.class' / 'instance') ensureDirectory.
+	(rootDirectory / 'Xyz.package' / 'A.class' / 'instance' / 'package.st') ensureFile.
+	artifactsFound := SquotFileSearchForArtifacts new
+		visit: rootDirectory with: fileStore tonelPackageLocator;
+		runSearch;
+		artifactsFound.
+	self assert: artifactsFound isEmpty.

--- a/src/SquotTonel-Tests.package/SquotTonelPackageLocatorTest.class/methodProperties.json
+++ b/src/SquotTonel-Tests.package/SquotTonelPackageLocatorTest.class/methodProperties.json
@@ -4,4 +4,5 @@
 	"instance" : {
 		"testFindsMultiplePackages" : "jr 3/10/2019 21:29",
 		"testFindsPackageInSubdirectory" : "jr 3/10/2019 21:30",
-		"testFindsPackageUnderRoot" : "jr 3/10/2019 21:30" } }
+		"testFindsPackageUnderRoot" : "jr 3/10/2019 21:30",
+		"testIgnoresCypressPackagesWithMethodNamedPackage" : "jr 1/9/2021 15:09" } }


### PR DESCRIPTION
If a cypress package contains a package method anywhere, the current heuristic will
consider this a tonel package. This change adds a check to see if it was found in a
cypress *.package directory.

This fix works but the overall logic is of course still rather fragile.