### PR TITLE
SquotGUI: Use new UIManager interface (#chooseOptionsFrom:...) for Squeak 6.0+

### DIFF
--- a/src/Squit.package/.squot-contents
+++ b/src/Squit.package/.squot-contents
@@ -1,7 +1,7 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
 	#id : UUID [ '207bca0df934e041b1e79b9ff315b588' ],
-	#objectsReplacedByNames : true,
 	#slotOverrides : { },
+	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/src/Squit.package/SquitBrowser.class/instance/actionBranch.st
+++ b/src/Squit.package/SquitBrowser.class/instance/actionBranch.st
@@ -11,7 +11,7 @@ actionBranch
 		initialName: nameSuggestion
 		ifCanceled: [^ self].
 	self loadBranchList; branchSelectionChanged.
-	(SquotGUI chooseFrom: #('Switch and move over unsaved changes' 'Switch but leave unsaved changes at current branch' 'Stay at current branch') values: #(switchMoveOver switchClean stayAtCurrent) title: 'Do you want to switch to the new branch?')
+	(SquotGUI chooseOptionFrom: #('Switch and move over unsaved changes' 'Switch but leave unsaved changes at current branch' 'Stay at current branch') values: #(switchMoveOver switchClean stayAtCurrent) title: 'Do you want to switch to the new branch?')
 		caseOf: 
 		{[#switchMoveOver] -> [self actionBranchSwitchMoveOver].
 		[#switchClean] -> [self actionBranchSwitch].

--- a/src/Squit.package/SquitBrowser.class/methodProperties.json
+++ b/src/Squit.package/SquitBrowser.class/methodProperties.json
@@ -16,7 +16,7 @@
 	"instance" : {
 		"aboutToStyle:" : "fn 4/11/2017 09:53",
 		"actionAddOrRemoveTrackedPackages" : "jr 8/29/2020 16:22",
-		"actionBranch" : "jr 12/22/2021 21:08",
+		"actionBranch" : "ct 6/12/2022 20:59",
 		"actionBranchAdd" : "jr 3/7/2020 00:41",
 		"actionBranchCreateAndSwitch" : "jr 8/29/2020 15:09",
 		"actionBranchDiffWithWorkingCopy" : "jr 3/7/2020 00:42",

--- a/src/Squit.package/SquitInteractiveRemoteOperation.class/instance/errorPushFailed..st
+++ b/src/Squit.package/SquitInteractiveRemoteOperation.class/instance/errorPushFailed..st
@@ -2,7 +2,7 @@ error handling
 errorPushFailed: aGitPushFailed
 	| answer |
 	answer := SquotGUI
-		chooseFrom:
+		chooseOptionFrom:
 			{'Retry' translated. 'Cancel' translated. 'Debug'} 
 		values: #(retry cancel debug)
 		title: aGitPushFailed messageText.

--- a/src/Squit.package/SquitInteractiveRemoteOperation.class/instance/errorRemoteAuthenticationFailed..st
+++ b/src/Squit.package/SquitInteractiveRemoteOperation.class/instance/errorRemoteAuthenticationFailed..st
@@ -10,7 +10,7 @@ errorRemoteAuthenticationFailed: aGitRemoteError
 		ifTrue: [message := message, String cr , 'Also please note: If you have two-factor authentification enabled,'
 			, String cr, 'you must use a personal access token instead of your GitHub login password.'].
 	answer := SquotGUI
-		chooseFrom:
+		chooseOptionFrom:
 			{'Retry' translated. 'Change credentials' translated. 'Cancel' translated. 'Debug'} 
 		values: #(retry dropCredentials cancel debug)
 		title: message.

--- a/src/Squit.package/SquitInteractiveRemoteOperation.class/methodProperties.json
+++ b/src/Squit.package/SquitInteractiveRemoteOperation.class/methodProperties.json
@@ -2,8 +2,8 @@
 	"class" : {
 		 },
 	"instance" : {
-		"errorPushFailed:" : "jr 9/4/2020 20:15",
-		"errorRemoteAuthenticationFailed:" : "jr 7/16/2021 23:03",
+		"errorPushFailed:" : "ct 6/12/2022 20:59",
+		"errorRemoteAuthenticationFailed:" : "ct 6/12/2022 20:59",
 		"errorRemoteResourceNotFound:" : "jr 8/3/2020 00:14",
 		"errorRemoteUndefined:" : "jr 8/2/2020 23:53",
 		"handleRemoteErrorsWhile:afterErrorDo:" : "jr 9/4/2020 20:11",

--- a/src/Squot.package/.squot-contents
+++ b/src/Squot.package/.squot-contents
@@ -1,7 +1,7 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
 	#id : UUID [ '7e0624d4d6eca84f879c365f65ae74be' ],
-	#objectsReplacedByNames : true,
 	#slotOverrides : { },
+	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/src/Squot.package/SquotGUI.class/class/chooseOptionFrom.values.title..st
+++ b/src/Squot.package/SquotGUI.class/class/chooseOptionFrom.values.title..st
@@ -1,0 +1,6 @@
+user interface
+chooseOptionFrom: labelsCollection values: valuesCollection title: aString
+	^ self runInUiProcess: [
+		(UIManager default respondsTo: #chooseOptionFrom:values:title:)
+			ifTrue: [UIManager default chooseOptionFrom: labelsCollection values: valuesCollection title: aString]
+			ifFalse: ["< ToolBuilder-Kernel-tpr.157" UIManager default chooseFrom: labelsCollection values: valuesCollection title: aString]]

--- a/src/Squot.package/SquotGUI.class/methodProperties.json
+++ b/src/Squot.package/SquotGUI.class/methodProperties.json
@@ -6,6 +6,7 @@
 		"chooseDirectory:from:" : "jr 8/8/2020 01:05",
 		"chooseFrom:values:title:" : "jr 7/24/2020 09:59",
 		"chooseMultipleFrom:values:title:" : "jr 8/7/2020 21:42",
+		"chooseOptionFrom:values:title:" : "ct 6/12/2022 21:16",
 		"confirm:" : "jr 7/24/2020 10:12",
 		"confirm:trueChoice:falseChoice:" : "jr 7/24/2020 10:13",
 		"displayProgress:during:" : "jr 9/13/2020 21:43",


### PR DESCRIPTION
Complements ToolBuilder-Kernel-tpr.157: When available, use modern `#chooseOptionFrom:title:` from `UIManager` instead of the classical `#chooseFrom:title:` that is intended for data only.

This restores the correct look for several dialogs, which looked not so nice recently:

![image](https://user-images.githubusercontent.com/38782922/173249770-1fc1fe61-0911-4c94-9aa1-117c870fc183.png)

Now they look beautiful again:

![image](https://user-images.githubusercontent.com/38782922/173249778-a24399d3-7b2e-4c35-83a5-56038015429f.png)

Note that I decided against using the options variant for choosing artifacts/remotes which are typically a small number of items only, but still arbitrary data, so we can't be sure about the exact number:

![image](https://user-images.githubusercontent.com/38782922/173249815-f8acc79d-8c60-4036-a470-d8b76e4d3a0e.png)

<small>Twin PR of https://github.com/hpi-swa/smalltalkCI/pull/555.</small>