### PR TITLE
Hide timezone in summary for commits of local timezone

### DIFF
--- a/src/Squit.package/.squot-contents
+++ b/src/Squit.package/.squot-contents
@@ -1,7 +1,7 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
 	#id : UUID [ '207bca0df934e041b1e79b9ff315b588' ],
-	#objectsReplacedByNames : true,
 	#slotOverrides : { },
+	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/src/Squit.package/SquitBrowser.class/instance/summaryForCommit..st
+++ b/src/Squit.package/SquitBrowser.class/instance/summaryForCommit..st
@@ -14,4 +14,4 @@ summaryForCommit: aSquitVersion
 		'Commit: ', commitHash, ', Parents: ', parents asCommaString, String cr,
 		'Author: ', author, String cr,
 		'Committer: ', committer, String cr,
-		'Date: ', timeStamp, String cr
+		'Date: ', timeStamp

--- a/src/Squit.package/SquitBrowser.class/instance/summaryForCommit..st
+++ b/src/Squit.package/SquitBrowser.class/instance/summaryForCommit..st
@@ -7,6 +7,9 @@ summaryForCommit: aSquitVersion
 	author := (aSquitVersion metadata at: #author), ' <', (aSquitVersion metadata at: #authorEmail), '>'.
 	committer := (aSquitVersion metadata at: #committer), ' <', (aSquitVersion metadata at: #committerEmail), '>'.
 	timeStamp := aSquitVersion metadata at: #timestamp.
+	timeStamp := timeStamp offsetSeconds = DateAndTime now offsetSeconds
+		ifTrue: [timeStamp asString allButLast: 6 "('+xx:00' size)"]
+		ifFalse: [timeStamp asString].
 	^ message withBlanksTrimmed, String cr, String cr,
 		'Commit: ', commitHash, ', Parents: ', parents asCommaString, String cr,
 		'Author: ', author, String cr,

--- a/src/Squit.package/SquitBrowser.class/methodProperties.json
+++ b/src/Squit.package/SquitBrowser.class/methodProperties.json
@@ -205,7 +205,7 @@
 		"soleParentOf:orChooseWithPrompt:" : "jr 1/23/2022 00:27",
 		"sortVersionsTopologically:" : "jr 2/8/2020 19:54",
 		"stepAt:in:" : "fn 4/11/2017 18:00",
-		"summaryForCommit:" : "jr 7/2/2022 21:02",
+		"summaryForCommit:" : "ct 9/11/2022 20:11",
 		"timeOfLastListUpdate" : "fn 4/11/2017 18:00",
 		"toggleMetadata" : "jr 3/17/2019 22:07",
 		"updateHistorianDecorationsMap" : "jr 7/2/2022 21:56",

--- a/src/Squit.package/SquitBrowser.class/methodProperties.json
+++ b/src/Squit.package/SquitBrowser.class/methodProperties.json
@@ -205,7 +205,7 @@
 		"soleParentOf:orChooseWithPrompt:" : "jr 1/23/2022 00:27",
 		"sortVersionsTopologically:" : "jr 2/8/2020 19:54",
 		"stepAt:in:" : "fn 4/11/2017 18:00",
-		"summaryForCommit:" : "ct 9/11/2022 20:11",
+		"summaryForCommit:" : "ct 9/11/2022 20:20",
 		"timeOfLastListUpdate" : "fn 4/11/2017 18:00",
 		"toggleMetadata" : "jr 3/17/2019 22:07",
 		"updateHistorianDecorationsMap" : "jr 7/2/2022 21:56",


### PR DESCRIPTION
This way, commits that have a timestamp from a different timestamp may be discovered more easily.

Closes #294.

---

The following screenshot were taken in summer time (+02:00):

|timestamp in summertime (+02:00)|timestamp in wintertime (+01:00)|
|-|-|
|![image](https://user-images.githubusercontent.com/38782922/189542957-e22d7530-61d0-4b3f-8781-3fd494a9f7a5.png)|![image](https://user-images.githubusercontent.com/38782922/189542966-76b94dea-6186-4655-bab7-f54a04ef4165.png)|