### PR TITLE
changes chooser: provide proper do-it receiver

### DIFF
--- a/src/Squot.package/MCPatchOperation.extension/instance/actualClassInSquotWorkingCopy..st
+++ b/src/Squot.package/MCPatchOperation.extension/instance/actualClassInSquotWorkingCopy..st
@@ -1,0 +1,3 @@
+*Squot-Tools
+actualClassInSquotWorkingCopy: aSquotWorkingCopyArtifact
+	^ self definition actualClassInSquotWorkingCopy: aSquotWorkingCopyArtifact

--- a/src/Squot.package/MCPatchOperation.extension/methodProperties.json
+++ b/src/Squot.package/MCPatchOperation.extension/methodProperties.json
@@ -2,6 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
+		"actualClassInSquotWorkingCopy:" : "ct 9/15/2022 18:57",
 		"browseFromSquotWorkingCopyArtifact:" : "jr 12/22/2019 20:26",
 		"ignoreInSquot" : "jr 4/14/2020 14:40",
 		"isCurrentlyIgnoredInSquot" : "jr 4/14/2020 14:18",

--- a/src/Squot.package/SquotChangesChooser.class/instance/doItContext.st
+++ b/src/Squot.package/SquotChangesChooser.class/instance/doItContext.st
@@ -1,0 +1,4 @@
+Smalltalk tools
+doItContext
+
+	^ nil

--- a/src/Squot.package/SquotChangesChooser.class/instance/doItReceiver.st
+++ b/src/Squot.package/SquotChangesChooser.class/instance/doItReceiver.st
@@ -1,0 +1,4 @@
+Smalltalk tools
+doItReceiver
+
+	^ self selectedClass ifNotNil: [:class | class theNonMetaClass]

--- a/src/Squot.package/SquotChangesChooser.class/methodProperties.json
+++ b/src/Squot.package/SquotChangesChooser.class/methodProperties.json
@@ -44,6 +44,8 @@
 		"diffNodeMenu:shifted:" : "jr 9/25/2020 18:27",
 		"diffNodeMenuHook:" : "jr 11/18/2020 15:26",
 		"diffText" : "jr 6/6/2022 19:12",
+		"doItContext" : "ct 9/15/2022 18:56",
+		"doItReceiver" : "ct 9/15/2022 18:57",
 		"environment" : "jr 7/9/2022 12:12",
 		"excludeMethodsWithOnlyTimestampChanges:" : "jr 3/8/2022 20:28",
 		"excludePackagesWithoutActiveChanges:" : "jr 3/8/2022 20:28",


### PR DESCRIPTION
So that you can evaluate snippets, especially class-side samples, with the same semantics as in a normal code holder.

![image](https://user-images.githubusercontent.com/38782922/190464734-e80eef23-a664-45ad-9165-0a2860fd4417.png)
