### PR TITLE
git browser/diff with parent: if commit has multiple parents, ask the user to choose one of them

### DIFF
--- a/src/Squit.package/SquitBrowser.class/instance/actionCommitDiffWithParent.st
+++ b/src/Squit.package/SquitBrowser.class/instance/actionCommitDiffWithParent.st
@@ -1,8 +1,21 @@
 actions on versions
 actionCommitDiffWithParent
 	self withUnitOfWork:
-		[(SquotDiffExplorer
-			from: (self commitSelection parents at: 1 ifAbsent: [SquotSnapshot empty])
+		[| label parent parents |
+		parents := self commitSelection parents.
+		label := 'Comparing versions'.
+		parent := parents
+			ifNotEmpty:
+				[parents size = 1
+					ifTrue: [parents anyOne]
+					ifFalse:
+						[(SquotGUI chooseFrom: parents values: parents title: 'Choose parent for diff')
+							ifNil: [^ self]]]
+			ifEmpty:
+				[label := '{1} (orphan commit)' format: {label}.
+				SquotSnapshot empty].
+		(SquotDiffExplorer
+			from: parent
 			to: self commitSelection)
 		workingCopy: self projectSelection;
-		openLabel: 'Comparing versions'].
+		openLabel: label].

--- a/src/Squit.package/SquitBrowser.class/methodProperties.json
+++ b/src/Squit.package/SquitBrowser.class/methodProperties.json
@@ -37,7 +37,7 @@
 		"actionCommit" : "jr 8/25/2021 09:57",
 		"actionCommitCherryPick" : "jr 8/8/2020 15:53",
 		"actionCommitDiffWithNextSelected" : "jr 7/2/2017 19:30",
-		"actionCommitDiffWithParent" : "jr 2/27/2020 01:00",
+		"actionCommitDiffWithParent" : "ct 9/15/2022 19:23",
 		"actionCommitDiffWithWorkingCopy" : "jr 3/7/2020 00:45",
 		"actionCommitMergeIntoMemory" : "jr 3/7/2020 00:45",
 		"actionCommitRevert" : "jr 1/23/2022 00:17",


### PR DESCRIPTION
The former behavior - automatically choosing the first parent - seemed less intuitive and flexible here.