### PR TITLE
experimental: indicate branches with stashes in git browser's commit list

### DIFF
--- a/src/Squit.package/SquitBrowser.class/instance/branchListIconAt..st
+++ b/src/Squit.package/SquitBrowser.class/instance/branchListIconAt..st
@@ -3,6 +3,10 @@ branchListIconAt: anIndex
 	anIndex > 1 ifFalse: [^ nil].
 	anIndex = indexOfActiveHistorianInBranchList
 		ifTrue: [^ ToolIcons testGreen].
+	(self projectSelection repository historianForTemporaryVersionsOn: (self projectSelection repository historianNamed: (self branchList at: anIndex))) ifNotNil: [:temporaryHistorian |
+		temporaryHistorian version ifNotNil: [:temporaryVersion |
+			(temporaryVersion parents notEmpty and: [(temporaryVersion patchRelativeToBase: temporaryVersion parents first) diffs notEmpty])
+				ifTrue: [^ ToolIcons testOrange]]].
 	anIndex > (indexOfFirstRemoteTrackingBranch ifNil: [self branchList size])
 		ifTrue: [^ ToolIcons arrowUp].
 	^ ToolIcons blank

--- a/src/Squit.package/SquitBrowser.class/methodProperties.json
+++ b/src/Squit.package/SquitBrowser.class/methodProperties.json
@@ -78,7 +78,7 @@
 		"addProjectIfCanceled:" : "jr 11/18/2021 22:49",
 		"branchButtonHelpText" : "jr 12/22/2021 21:09",
 		"branchList" : "jr 12/22/2021 23:46",
-		"branchListIconAt:" : "jr 5/14/2021 22:57",
+		"branchListIconAt:" : "ct 10/4/2022 21:04",
 		"branchListIfRepositoryDoesNotExist" : "jr 12/22/2021 23:45",
 		"branchListMenu:shifted:" : "jr 1/13/2018 00:31",
 		"branchSelection" : "jr 6/27/2020 09:50",


### PR DESCRIPTION
This is an experimental patch that should only serve as inspiration in its current form! It is still very (!) slow and would require optimizations. Maybe we can compare two versions binarily without checking all their diffs? Maybe there is something like a per-historian cache that we could use? ...