### PR TITLE
Fix log rotation

### DIFF
--- a/src/FileSystem-Git.package/GitStore.class/class/cleanUp..st
+++ b/src/FileSystem-Git.package/GitStore.class/class/cleanUp..st
@@ -1,0 +1,5 @@
+initialize-release
+cleanUp: aggressive
+
+	aggressive ifTrue:
+		[LogMessages := LogMessageCount := nil].

--- a/src/FileSystem-Git.package/GitStore.class/class/logMessage..st
+++ b/src/FileSystem-Git.package/GitStore.class/class/logMessage..st
@@ -9,5 +9,8 @@ logMessage: aString
 	maxLogSize := 5000 "if each entry measures 200B, this would be up to 1MB".
 	(LogMutex ifNil: [LogMutex := Mutex new]) critical:
 		[LogMessages ifNil: [LogMessages := LinkedList new].
-		LogMessages size >= maxLogSize ifTrue: [LogMessages removeFirst].
+		LogMessageCount ifNil: [LogMessageCount := LogMessages size].
+		LogMessageCount >= maxLogSize
+			ifTrue: [LogMessages removeFirst]
+			ifFalse: [LogMessageCount := LogMessageCount + 1].
 		LogMessages add: DateAndTime now printString, String cr, aString]

--- a/src/FileSystem-Git.package/GitStore.class/class/logMessage..st
+++ b/src/FileSystem-Git.package/GitStore.class/class/logMessage..st
@@ -9,6 +9,5 @@ logMessage: aString
 	maxLogSize := 5000 "if each entry measures 200B, this would be up to 1MB".
 	(LogMutex ifNil: [LogMutex := Mutex new]) critical:
 		[LogMessages ifNil: [LogMessages := LinkedList new].
-		LogMessageCount ifNil: [LogMessageCount := LogMessages size].
-		LogMessageCount >= maxLogSize ifTrue: [LogMessages removeFirst].
+		LogMessages size >= maxLogSize ifTrue: [LogMessages removeFirst].
 		LogMessages add: DateAndTime now printString, String cr, aString]

--- a/src/FileSystem-Git.package/GitStore.class/methodProperties.json
+++ b/src/FileSystem-Git.package/GitStore.class/methodProperties.json
@@ -1,6 +1,7 @@
 {
 	"class" : {
 		"cache:" : "CamilloBruni 8/30/2012 14:04",
+		"cleanUp:" : "ct 1/10/2024 18:18",
 		"logMessage:" : "ct 1/10/2024 18:17",
 		"memory" : "CamilloBruni 8/30/2012 14:04",
 		"openLog" : "jr 6/29/2017 10:42" },

--- a/src/FileSystem-Git.package/GitStore.class/methodProperties.json
+++ b/src/FileSystem-Git.package/GitStore.class/methodProperties.json
@@ -1,7 +1,7 @@
 {
 	"class" : {
 		"cache:" : "CamilloBruni 8/30/2012 14:04",
-		"logMessage:" : "jr 11/28/2021 10:51",
+		"logMessage:" : "ct 1/10/2024 16:23",
 		"memory" : "CamilloBruni 8/30/2012 14:04",
 		"openLog" : "jr 6/29/2017 10:42" },
 	"instance" : {

--- a/src/FileSystem-Git.package/GitStore.class/methodProperties.json
+++ b/src/FileSystem-Git.package/GitStore.class/methodProperties.json
@@ -1,7 +1,7 @@
 {
 	"class" : {
 		"cache:" : "CamilloBruni 8/30/2012 14:04",
-		"logMessage:" : "ct 1/10/2024 16:23",
+		"logMessage:" : "ct 1/10/2024 18:17",
 		"memory" : "CamilloBruni 8/30/2012 14:04",
 		"openLog" : "jr 6/29/2017 10:42" },
 	"instance" : {

--- a/src/FileSystem-Git.package/GitStore.class/properties.json
+++ b/src/FileSystem-Git.package/GitStore.class/properties.json
@@ -3,6 +3,7 @@
 	"classinstvars" : [
 		 ],
 	"classvars" : [
+		"LogMessageCount",
 		"LogMessages",
 		"LogMutex" ],
 	"commentStamp" : "CamilloBruni 8/1/2011 18:33",

--- a/src/FileSystem-Git.package/GitStore.class/properties.json
+++ b/src/FileSystem-Git.package/GitStore.class/properties.json
@@ -3,7 +3,6 @@
 	"classinstvars" : [
 		 ],
 	"classvars" : [
-		"LogMessageCount",
 		"LogMessages",
 		"LogMutex" ],
 	"commentStamp" : "CamilloBruni 8/1/2011 18:33",

--- a/src/FileSystem-Git.package/monticello.meta/postscript.st
+++ b/src/FileSystem-Git.package/monticello.meta/postscript.st
@@ -32,4 +32,12 @@ FileSystemGitCompatibility hadInadequateFromUnixTimeImplementation ifFalse:
 	changeRecord ifNotNil:
 		[[changeRecord fileIn]
 			ensure: [Smalltalk globals removeKey: #TEMP_Squot_ShadowedChangeRecord255]]].
-FileSystemGitCompatibility ensureValidFromUnixTimeImplementation.'!
+FileSystemGitCompatibility ensureValidFromUnixTimeImplementation.
+
+"2024-01-10: fix git log rotation and truncate older logs, see https://github.com/hpi-swa/Squot/pull/410"
+(GitStore classPool at: #LogMessages) ifNotNil: [:logMessages |
+	| count |
+	count := logMessages size.
+	GitStore classPool
+		at: #LogMessages put: ((logMessages asArray last: (count := 5000 clampHigh: count)) as: LinkedList) "forth and back conversion to avoid inefficient LinkedList(...)>>#last: (quadratic in older versions of Squeak)";
+		at: #LogMessageCount put: count].'!


### PR DESCRIPTION
Previously the counter was never updated, which occupied >145 MB in one of my images. This patch fixes log rotation and truncates existing oversized logs via postscript.